### PR TITLE
Clamp pulse energy and default to bars

### DIFF
--- a/PhoenixVisualizer/PhoenixVisualizer.Visuals/PulseVisualizer.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Visuals/PulseVisualizer.cs
@@ -25,7 +25,11 @@ public sealed class PulseVisualizer : IVisualizerPlugin
         canvas.Clear(0xFF000000);
         float size = Math.Min(_width, _height);
         float baseRadius = size * 0.15f;
-        float radius = baseRadius + features.Energy * size * 0.35f;
+
+        // Energy can spike way above 1, so cap it to keep the circle on screen 🚫🎯
+        float energy = MathF.Min(1f, features.Energy);
+        float radius = baseRadius + energy * size * 0.35f;
+
         uint color = features.Beat ? 0xFFFFFFFFu : 0xFFFFAA00u;
         canvas.FillCircle(_width / 2f, _height / 2f, radius, color);
     }


### PR DESCRIPTION
## Summary
- cap pulse visualizer energy so the circle stays within bounds
- prefer simple bars plugin by default for a predictable start

## Testing
- `dotnet build PhoenixVisualizer/PhoenixVisualizer.sln`
- `dotnet run --project PhoenixVisualizer/PhoenixVisualizer.App` *(fails: XOpenDisplay failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d40bb1f083329704dd0dd08bad63