### PR TITLE
Fix AVS effect node compile issues

### DIFF
--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/CompositeEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/CompositeEffectsNode.cs
@@ -16,23 +16,25 @@ public class CompositeEffectsNode : BaseEffectNode
         AddOutput("Result");
     }
 
-    protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
-    {
-        var a = GetInput<ImageBuffer>("A");
-        var b = GetInput<ImageBuffer>("B");
-        var result = GetOutput<ImageBuffer>("Result");
-        if (a == null || b == null || result == null) return result;
-
-        for (int y = 0; y < result.Height; y++)
-        for (int x = 0; x < result.Width; x++)
+        protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
         {
-            var ca = a[x, y];
-            var cb = b[x, y];
-            result[x, y] = Blend(ca, cb);
+            var a = GetInput<ImageBuffer>("A");
+            var b = GetInput<ImageBuffer>("B");
+            var result = GetOutput<ImageBuffer>("Result");
+            if (a == null || b == null || result == null) return result;
+
+            for (int y = 0; y < result.Height; y++)
+            for (int x = 0; x < result.Width; x++)
+            {
+                // Convert raw pixels to Avalonia colors for blending
+                var ca = Color.FromUInt32((uint)a[x, y]);
+                var cb = Color.FromUInt32((uint)b[x, y]);
+                var blended = Blend(ca, cb);
+                result[x, y] = (int)(((uint)blended.A << 24) | ((uint)blended.R << 16) | ((uint)blended.G << 8) | blended.B);
+            }
+
+            return result;
         }
-        
-        return result;
-    }
 
     private Color Blend(Color a, Color b)
     {

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/GodRaysEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/GodRaysEffectsNode.cs
@@ -17,41 +17,42 @@ public class GodRaysEffectsNode : BaseEffectNode
         AddOutput("Result");
     }
 
-    protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
-    {
-        var src = GetInput<ImageBuffer>("Source");
-        var dst = GetOutput<ImageBuffer>("Result");
-        if (src == null || dst == null) return dst;
-
-        dst.Clear();
-        int cx = dst.Width / 2, cy = dst.Height / 2;
-        for (int y = 0; y < dst.Height; y++)
+        protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
         {
-            for (int x = 0; x < dst.Width; x++)
+            var src = GetInput<ImageBuffer>("Source");
+            var dst = GetOutput<ImageBuffer>("Result");
+            if (src == null || dst == null) return dst;
+
+            dst.Clear();
+            int cx = dst.Width / 2, cy = dst.Height / 2;
+            for (int y = 0; y < dst.Height; y++)
             {
-                var c = src[x, y];
-                if (c.A > 10) // bright pixel
+                for (int x = 0; x < dst.Width; x++)
                 {
-                    int dx = x - cx, dy = y - cy;
-                    for (int k = 0; k < 50; k++)
+                    var c = Color.FromUInt32((uint)src[x, y]);
+                    if (c.A > 10) // bright pixel
                     {
-                        int nx = cx + dx * k / 50;
-                        int ny = cy + dy * k / 50;
-                        if (nx >= 0 && nx < dst.Width && ny >= 0 && ny < dst.Height)
+                        int dx = x - cx, dy = y - cy;
+                        for (int k = 0; k < 50; k++)
                         {
-                            var oc = dst[nx, ny];
-                            dst[nx, ny] = Color.FromArgb(255,
-                                Clamp(oc.R + (byte)(c.R * Intensity * Math.Pow(Decay, k))),
-                                Clamp(oc.G + (byte)(c.G * Intensity * Math.Pow(Decay, k))),
-                                Clamp(oc.B + (byte)(c.B * Intensity * Math.Pow(Decay, k))));
+                            int nx = cx + dx * k / 50;
+                            int ny = cy + dy * k / 50;
+                            if (nx >= 0 && nx < dst.Width && ny >= 0 && ny < dst.Height)
+                            {
+                                var oc = Color.FromUInt32((uint)dst[nx, ny]);
+                                var nc = Color.FromArgb(255,
+                                    Clamp(oc.R + (byte)(c.R * Intensity * Math.Pow(Decay, k))),
+                                    Clamp(oc.G + (byte)(c.G * Intensity * Math.Pow(Decay, k))),
+                                    Clamp(oc.B + (byte)(c.B * Intensity * Math.Pow(Decay, k))));
+                                dst[nx, ny] = (int)(((uint)nc.A << 24) | ((uint)nc.R << 16) | ((uint)nc.G << 8) | nc.B);
+                            }
                         }
                     }
                 }
             }
+
+            return dst;
         }
-        
-        return dst;
-    }
 
     private static byte Clamp(double v) => (byte)(v < 0 ? 0 : v > 255 ? 255 : v);
 }

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/OnetoneEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/OnetoneEffectsNode.cs
@@ -17,25 +17,26 @@ public class OnetoneEffectsNode : BaseEffectNode
 
     protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
     {
-        var src = GetInput<ImageBuffer>("Source");
-        var dst = GetOutput<ImageBuffer>("Result");
-        if (src == null || dst == null) return dst;
+            var src = GetInput<ImageBuffer>("Source");
+            var dst = GetOutput<ImageBuffer>("Result");
+            if (src == null || dst == null) return dst;
 
-        for (int y = 0; y < src.Height; y++)
-        for (int x = 0; x < src.Width; x++)
-        {
-            var c = src[x, y];
-            dst[x, y] = Channel switch
+            for (int y = 0; y < src.Height; y++)
+            for (int x = 0; x < src.Width; x++)
             {
-                "R" => Color.FromRgb(c.R, 0, 0),
-                "G" => Color.FromRgb(0, c.G, 0),
-                "B" => Color.FromRgb(0, 0, c.B),
-                _ => Gray(c)
-            };
+                var c = Color.FromUInt32((uint)src[x, y]);
+                var nc = Channel switch
+                {
+                    "R" => Color.FromRgb(c.R, 0, 0),
+                    "G" => Color.FromRgb(0, c.G, 0),
+                    "B" => Color.FromRgb(0, 0, c.B),
+                    _ => Gray(c)
+                };
+                dst[x, y] = (int)(((uint)nc.A << 24) | ((uint)nc.R << 16) | ((uint)nc.G << 8) | nc.B);
+            }
+
+            return dst;
         }
-        
-        return dst;
-    }
 
     private Color Gray(Color c)
     {

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/OscilloscopeStarEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/OscilloscopeStarEffectsNode.cs
@@ -36,12 +36,12 @@ public class OscilloscopeStarEffectsNode : BaseEffectNode
         target.Clear();
         for (int i = 0; i < _stars.Count; i++)
         {
-            var (x, y) = _stars[i];
-            int offset = (int)(Math.Sin(audio.Time + i) * 20);
-            int nx = (x + offset) % target.Width;
-            int ny = (y + offset) % target.Height;
-            if (nx >= 0 && nx < target.Width && ny >= 0 && ny < target.Height)
-                target[nx, ny] = StarColor;
+                var (x, y) = _stars[i];
+                int offset = (int)(Math.Sin(audio.Time + i) * 20);
+                int nx = (x + offset) % target.Width;
+                int ny = (y + offset) % target.Height;
+                if (nx >= 0 && nx < target.Width && ny >= 0 && ny < target.Height)
+                    target[nx, ny] = (int)(((uint)StarColor.A << 24) | ((uint)StarColor.R << 16) | ((uint)StarColor.G << 8) | StarColor.B);
         }
         
         return target;

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/PartsEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/PartsEffectsNode.cs
@@ -17,21 +17,32 @@ public class PartsEffectsNode : BaseEffectNode
 
     protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audio)
     {
-        var src = GetInput<ImageBuffer>("Source");
-        var dst = GetOutput<ImageBuffer>("Result");
-        if (src == null || dst == null) return dst;
+            var src = GetInput<ImageBuffer>("Source");
+            var dst = GetOutput<ImageBuffer>("Result");
+            if (src == null || dst == null) return dst;
 
-        dst.Clear();
-        for (int y = 0; y < src.Height; y += TileSize)
-        {
-            for (int x = 0; x < src.Width; x += TileSize)
+            dst.Clear();
+            for (int y = 0; y < src.Height; y += TileSize)
             {
-                int nx = (x + (int)(audio.Bass * 10)) % dst.Width;
-                int ny = (y + (int)(audio.Mid * 10)) % dst.Height;
-                dst.Blit(src, x, y, TileSize, TileSize, nx, ny);
+                for (int x = 0; x < src.Width; x += TileSize)
+                {
+                    int nx = (x + (int)(audio.Bass * 10)) % dst.Width;
+                    int ny = (y + (int)(audio.Mid * 10)) % dst.Height;
+
+                    for (int ty = 0; ty < TileSize; ty++)
+                    for (int tx = 0; tx < TileSize; tx++)
+                    {
+                        int sx = x + tx;
+                        int sy = y + ty;
+                        int dx = nx + tx;
+                        int dy = ny + ty;
+                        if (sx < 0 || sx >= src.Width || sy < 0 || sy >= src.Height) continue;
+                        if (dx < 0 || dx >= dst.Width || dy < 0 || dy >= dst.Height) continue;
+                        dst[dx, dy] = src[sx, sy];
+                    }
+                }
             }
+
+            return dst;
         }
-        
-        return dst;
-    }
 }

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/ShiftEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/ShiftEffectsNode.cs
@@ -457,9 +457,9 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
             uint sA = (src >> 24) & 0xFF, sR = (src >> 16) & 0xFF, sG = (src >> 8) & 0xFF, sB = src & 0xFF;
 
             uint rA = Math.Max(dA, sA);
-            uint rR = Math.Max(0u, (int)dR - (int)sR);
-            uint rG = Math.Max(0u, (int)dG - (int)sG);
-            uint rB = Math.Max(0u, (int)dB - (int)sB);
+            uint rR = (uint)Math.Max(0, (int)dR - (int)sR);
+            uint rG = (uint)Math.Max(0, (int)dG - (int)sG);
+            uint rB = (uint)Math.Max(0, (int)dB - (int)sB);
 
             return (rA << 24) | (rR << 16) | (rG << 8) | rB;
         }

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/StarfieldEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/StarfieldEffectsNode.cs
@@ -50,13 +50,14 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
 
         protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audioFeatures)
         {
-            if (!Enabled) return;
+            // If the effect is disabled, bail out gracefully ✨
+            if (!Enabled) return null;
 
             try
             {
-                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputData);
-                var outputImage = backgroundImage != null ? 
-                    new ImageBuffer(backgroundImage.Width, backgroundImage.Height) : 
+                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputs);
+                var outputImage = backgroundImage != null ?
+                    new ImageBuffer(backgroundImage.Width, backgroundImage.Height) :
                     new ImageBuffer(640, 480);
 
                 if (backgroundImage != null)
@@ -76,6 +77,9 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
             {
                 System.Diagnostics.Debug.WriteLine($"[Starfield Effects] Error: {ex.Message}");
             }
+
+            // Something went wrong, so return null 🛠️
+            return null;
         }
 
         private void InitializeStars()

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/TexturedParticleSystemEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/TexturedParticleSystemEffectsNode.cs
@@ -178,13 +178,14 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
 
         protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audioFeatures)
         {
-            if (!Enabled) return;
+            // Early exit if we're not supposed to render anything 🌙
+            if (!Enabled) return null;
 
             try
             {
-                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputData);
-                var outputImage = backgroundImage != null ? 
-                    new ImageBuffer(backgroundImage.Width, backgroundImage.Height) : 
+                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputs);
+                var outputImage = backgroundImage != null ?
+                    new ImageBuffer(backgroundImage.Width, backgroundImage.Height) :
                     new ImageBuffer(640, 480);
 
                 // Copy background
@@ -205,7 +206,7 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
 
                 // Update particle system
                 UpdateParticleSystem(outputImage.Width, outputImage.Height, audioFeatures);
-                
+
                 // Render particles
                 RenderParticles(outputImage, audioFeatures);
 
@@ -215,6 +216,9 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
             {
                 System.Diagnostics.Debug.WriteLine($"[Textured Particle System] Error: {ex.Message}");
             }
+
+            // In case of errors, return null so callers can handle gracefully 🛠️
+            return null;
         }
 
         #endregion
@@ -415,7 +419,8 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
                     SetEmitterPosition(ref particle);
                     
                     // Set initial velocity
-                    float angle = (float)_random.NextDouble() * VelocityAngleSpread * Math.PI / 180.0f;
+                    // Generate a launch angle in radians 🎯
+                    float angle = (float)(_random.NextDouble() * VelocityAngleSpread * Math.PI / 180.0);
                     float speed = InitialVelocityMin + (float)_random.NextDouble() * (InitialVelocityMax - InitialVelocityMin);
                     particle.VX = (float)Math.Cos(angle) * speed;
                     particle.VY = (float)Math.Sin(angle) * speed;
@@ -445,7 +450,7 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
                     break;
                     
                 case 1: // Circle
-                    float angle = (float)_random.NextDouble() * 2 * Math.PI;
+                    float angle = (float)(_random.NextDouble() * 2 * Math.PI);
                     float radius = (float)_random.NextDouble() * EmitterRadius;
                     particle.X = EmitterX + (float)Math.Cos(angle) * radius;
                     particle.Y = EmitterY + (float)Math.Sin(angle) * radius;

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/VectorFieldEffectsNode.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Effects/Nodes/AvsEffects/VectorFieldEffectsNode.cs
@@ -235,11 +235,12 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
 
         protected override object ProcessCore(Dictionary<string, object> inputs, AudioFeatures audioFeatures)
         {
-            if (!Enabled) return;
+            // Skip processing when disabled 🚫
+            if (!Enabled) return null;
 
             try
             {
-                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputData);
+                var backgroundImage = GetInputValue<ImageBuffer>("Background", inputs);
                 var outputImage = backgroundImage != null ? 
                     new ImageBuffer(backgroundImage.Width, backgroundImage.Height) : 
                     new ImageBuffer(640, 480);
@@ -289,6 +290,9 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
             {
                 System.Diagnostics.Debug.WriteLine($"[Vector Field Effects] Error: {ex.Message}");
             }
+
+            // Return null if something funky happens 🧪
+            return null;
         }
 
         #endregion
@@ -780,9 +784,9 @@ namespace PhoenixVisualizer.Core.Effects.Nodes.AvsEffects
             {
                 uint pixel = _persistenceBuffer.Data[i];
                 uint a = (uint)((pixel >> 24) * PersistenceDecay);
-                uint r = (uint)((pixel >> 16) & 0xFF * PersistenceDecay);
-                uint g = (uint)((pixel >> 8) & 0xFF * PersistenceDecay);
-                uint b = (uint)((pixel & 0xFF) * PersistenceDecay);
+                uint r = (uint)(((pixel >> 16) & 0xFF) * PersistenceDecay);
+                uint g = (uint)(((pixel >> 8) & 0xFF) * PersistenceDecay);
+                uint b = (uint)(((pixel) & 0xFF) * PersistenceDecay);
                 
                 _persistenceBuffer.Data[i] = (a << 24) | (r << 16) | (g << 8) | b;
                 

--- a/PhoenixVisualizer/PhoenixVisualizer.Core/Models/ImageBuffer.cs
+++ b/PhoenixVisualizer/PhoenixVisualizer.Core/Models/ImageBuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using Avalonia.Media.Imaging;
 
 namespace PhoenixVisualizer.Core.Models
 {
@@ -94,6 +95,11 @@ namespace PhoenixVisualizer.Core.Models
         public void DrawText(string text, Typeface typeface, int fontSize, Color color, Point position)
         {
             // TODO: Implement text drawing using System.Drawing
+        }
+
+        public void DrawBitmap(Avalonia.Media.Imaging.Bitmap bitmap, int x, int y, int width, int height)
+        {
+            // TODO: Implement bitmap drawing if needed
         }
     }
 


### PR DESCRIPTION
## Summary
- fix null returns and background handling in several AVS effect nodes
- correct color conversions and math for particle/visual nodes
- add bitmap stub and tiling copy logic to ImageBuffer

## Testing
- `dotnet build PhoenixVisualizer/PhoenixVisualizer.sln` *(fails: VFX and drawing utilities still have unresolved type issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b0419d685c833283be9e62e994d665